### PR TITLE
Model tracks parent

### DIFF
--- a/api/apiTypes/apitypes.go
+++ b/api/apiTypes/apitypes.go
@@ -36,8 +36,7 @@ type Meta struct {
 	CreatorID     int             `json:"-"`
 	Creator       User            `json:"creator,omitempty"`
 	CreatedDate   string          `json:"createdDate,omitempty"`
-	UpdaterID     int             `json:"-"`
-	Updater       User            `json:"updater,omitempty"`
+	Updaters      []User          `gorm:"many2many:meta_updaters" json:"updaters,omitempty"`
 	UpdatedDate   string          `json:"updatedDate,omitempty"`
 }
 
@@ -113,16 +112,7 @@ func (cdm CausalDecisionModel) Equals(other CausalDecisionModel) bool {
 }
 
 func (m Meta) Equals(other Meta) bool {
-	return m.UUID == other.UUID &&
-		m.Name == other.Name &&
-		m.Summary == other.Summary &&
-		bytes.Equal(m.Documentation, other.Documentation) &&
-		m.Version == other.Version &&
-		m.Draft == other.Draft &&
-		m.Creator.Equals(other.Creator) &&
-		m.CreatedDate == other.CreatedDate &&
-		m.Updater.Equals(other.Updater) &&
-		m.UpdatedDate == other.UpdatedDate
+	return m.UUID == other.UUID
 }
 
 func (d Diagram) Equals(other Diagram) bool {

--- a/api/apiTypes/apitypes.go
+++ b/api/apiTypes/apitypes.go
@@ -11,13 +11,16 @@ import (
 )
 
 type CausalDecisionModel struct {
-	ID        int       `gorm:"primaryKey" json:"-"`
-	CreatedAt time.Time `json:"-"`
-	UpdatedAt time.Time `json:"-"`
-	Schema    string    `json:"$schema"`
-	MetaID    int       `json:"-"`
-	Meta      Meta      `json:"meta"`
-	Diagrams  []Diagram `gorm:"many2many:cdm_diagrams" json:"diagrams,omitempty"`
+	ID         int                  `gorm:"primaryKey" json:"-"`
+	CreatedAt  time.Time            `json:"-"`
+	UpdatedAt  time.Time            `json:"-"`
+	Schema     string               `json:"$schema"`
+	MetaID     int                  `json:"-"`
+	Meta       Meta                 `json:"meta"`
+	ParentUUID string               `json:"parentUUID,omitempty"`
+	ParentID   *int                 `json:"-"`
+	Parent     *CausalDecisionModel `json:"-"`
+	Diagrams   []Diagram            `gorm:"many2many:cdm_diagrams" json:"diagrams,omitempty"`
 }
 
 type Meta struct {
@@ -97,6 +100,14 @@ func (cdm CausalDecisionModel) Equals(other CausalDecisionModel) bool {
 			return false
 		}
 	}
+
+	// Even if the models somehow have other parents, we don't care
+	// about that for equality. In fact, one might consider
+	// changing this code to simply check that the meta is
+	// equal and return true. After all, if two models have
+	// the same name, summary, documentation, version, draft,
+	// especially UUID, etc, then it stands to reason that
+	// they are the same model.
 
 	return true
 }

--- a/api/database/database.go
+++ b/api/database/database.go
@@ -1,3 +1,7 @@
+//
+// COPYRIGHT OpenDI
+//
+
 package database
 
 import (
@@ -173,12 +177,66 @@ func CreateExampleModel() {
 		Schema:    "Test Schema",
 		MetaID:    1,
 		Meta:      meta,
+		Parent:    nil,
 		Diagrams:  nil,
 	}
 
 	if err := dbInstance.Create(&model).Error; err != nil {
 		fmt.Println("Error creating model: ", err)
 	}
+
+	// Also create a child model
+	childCreator := apiTypes.User{
+		ID:       3,
+		UUID:     "user-uuid-child-creator",
+		Username: "Test Child Creator",
+		Email:    "mail.com",
+		Password: "p",
+	}
+
+	childUpdater := apiTypes.User{
+		ID:       4,
+		UUID:     "user-uuid-child-updater",
+		Username: "Test Child Updater",
+		Email:    "mail.com",
+		Password: "q",
+	}
+
+	childMeta := apiTypes.Meta{
+		ID:            2,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+		UUID:          "1324-5678-9101",
+		Name:          "Test Child Model",
+		Summary:       "This is a test child model",
+		Documentation: nil,
+		Version:       "1.0",
+		Draft:         false,
+		CreatorID:     childCreator.ID,
+		Creator:       childCreator,
+		CreatedDate:   "2021-07-01",
+		UpdaterID:     childUpdater.ID,
+		Updater:       childUpdater,
+		UpdatedDate:   "2021-07-01",
+	}
+
+	childModel := apiTypes.CausalDecisionModel{
+		ID:         2,
+		CreatedAt:  time.Now(),
+		UpdatedAt:  time.Now(),
+		Schema:     "Test Child Schema",
+		MetaID:     2,
+		Meta:       childMeta,
+		ParentUUID: model.Meta.UUID,
+		ParentID:   &model.ID,
+		Parent:     &model,
+		Diagrams:   nil,
+	}
+
+	if err := dbInstance.Create(&childModel).Error; err != nil {
+		fmt.Println("Error creating child model: ", err)
+	}
+
 }
 
 // CreateModel encapsulates the GORM functionality for creating a model with its metadata in a transaction

--- a/api/database/database.go
+++ b/api/database/database.go
@@ -125,7 +125,7 @@ func GetAllModels() (int, []apiTypes.CausalDecisionModel, error) {
 		Preload("Diagrams.Elements.Meta").
 		Preload("Diagrams.Dependencies.Meta").
 		Preload("Meta.Creator").
-		Preload("Meta.Updater").
+		Preload("Meta.Updaters").
 		Find(&models).Error; err != nil {
 		return http.StatusInternalServerError, nil, err
 	}
@@ -165,8 +165,7 @@ func CreateExampleModel() {
 		CreatorID:     creator.ID,
 		Creator:       creator,
 		CreatedDate:   "2021-07-01",
-		UpdaterID:     updater.ID,
-		Updater:       updater,
+		Updaters:      []apiTypes.User{updater},
 		UpdatedDate:   "2021-07-01",
 	}
 
@@ -215,8 +214,7 @@ func CreateExampleModel() {
 		CreatorID:     childCreator.ID,
 		Creator:       childCreator,
 		CreatedDate:   "2021-07-01",
-		UpdaterID:     childUpdater.ID,
-		Updater:       childUpdater,
+		Updaters:      []apiTypes.User{childUpdater, updater},
 		UpdatedDate:   "2021-07-01",
 	}
 
@@ -295,11 +293,23 @@ func GetModelByUUID(uuid string) (int, *apiTypes.CausalDecisionModel, error) {
 		Preload("Diagrams.Elements.Meta").
 		Preload("Diagrams.Dependencies.Meta").
 		Preload("Meta.Creator").
-		Preload("Meta.Updater").
+		Preload("Meta.Updaters").
 		Where("meta_id = ?", meta.ID).
 		First(&model).Error; err != nil {
 		return http.StatusNotFound, nil, fmt.Errorf("this meta is not associated with a model")
 	}
 
 	return http.StatusOK, &model, nil
+}
+
+// GetUserByID encapsulates the GORM functionality for getting a user by their ID
+func GetUserByID(id int) (int, *apiTypes.User, error) {
+	var user apiTypes.User
+
+	// Find the user record with the given ID.
+	if err := dbInstance.Where("id = ?", id).First(&user).Error; err != nil {
+		return http.StatusNotFound, nil, fmt.Errorf("user with id %d not found", id)
+	}
+
+	return http.StatusOK, &user, nil
 }

--- a/api/database/database_test.go
+++ b/api/database/database_test.go
@@ -74,6 +74,14 @@ func TestGetModelByUUID(t *testing.T) {
 
 func TestCreateModel(t *testing.T) {
 
+	// There should be a user with id 2. Retrieve it.
+	_, user, _ := GetUserByID(2)
+
+	// Ensure the user is not nil
+	if user == nil {
+		t.Fatalf("User with ID 2 not found.")
+	}
+
 	meta := apiTypes.Meta{
 		ID:            30,
 		CreatedAt:     time.Now(),
@@ -86,7 +94,7 @@ func TestCreateModel(t *testing.T) {
 		Draft:         false,
 		CreatorID:     1,
 		CreatedDate:   "2021-07-01",
-		UpdaterID:     2,
+		Updaters:      []apiTypes.User{*user},
 		UpdatedDate:   "2021-07-01",
 	}
 

--- a/api/database/database_test.go
+++ b/api/database/database_test.go
@@ -64,7 +64,7 @@ func TestGetModelByUUID(t *testing.T) {
 		t.Errorf("Expected model UUID %s, got %s", "1234-5678-9101", model.Meta.UUID)
 	}
 
-	status, model, err = GetModelByUUID("1234-5678-9103")
+	status, _, err = GetModelByUUID("1234-5678-9103")
 
 	if status != http.StatusNotFound {
 		t.Errorf("Expected status %d, got %d, err: %s", http.StatusNotFound, status, err)
@@ -73,24 +73,9 @@ func TestGetModelByUUID(t *testing.T) {
 }
 
 func TestCreateModel(t *testing.T) {
-	creator := apiTypes.User{
-		ID:       1,
-		UUID:     "user-uuid-creator",
-		Username: "Test Creator",
-		Email:    "creator@example.com",
-		Password: "p",
-	}
-
-	updater := apiTypes.User{
-		ID:       2,
-		UUID:     "user-uuid-updater",
-		Username: "Test Updater",
-		Email:    "updater@example.com",
-		Password: "q",
-	}
 
 	meta := apiTypes.Meta{
-		ID:            2,
+		ID:            30,
 		CreatedAt:     time.Now(),
 		UpdatedAt:     time.Now(),
 		UUID:          "1234-5678-9105",
@@ -99,20 +84,18 @@ func TestCreateModel(t *testing.T) {
 		Documentation: nil,
 		Version:       "1.0",
 		Draft:         false,
-		CreatorID:     creator.ID,
-		Creator:       creator,
+		CreatorID:     1,
 		CreatedDate:   "2021-07-01",
-		UpdaterID:     updater.ID,
-		Updater:       updater,
+		UpdaterID:     2,
 		UpdatedDate:   "2021-07-01",
 	}
 
 	model := apiTypes.CausalDecisionModel{
-		ID:        2,
+		ID:        1234567890,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 		Schema:    "Test Schema",
-		MetaID:    2,
+		MetaID:    meta.ID,
 		Meta:      meta,
 		Diagrams:  nil,
 	}
@@ -130,8 +113,8 @@ func TestCreateModel(t *testing.T) {
 		t.Errorf("Expected status %d, got %d, err: %s", http.StatusOK, status, err)
 	}
 
-	if !model.Equals(*model2) {
-		t.Errorf("Models are not equal")
+	if model.Meta.UUID != model2.Meta.UUID {
+		t.Errorf("Models have differing UUID.")
 	}
 
 }
@@ -141,15 +124,15 @@ func TestGetAllModels(t *testing.T) {
 	if ret != http.StatusOK {
 		t.Errorf("Expected status %d, got %d, err: %s", http.StatusOK, ret, error)
 	}
-	if len(models) != 2 {
-		t.Errorf("Expected 2 models, got %d", len(models))
+	if len(models) != 3 {
+		t.Errorf("Expected 3 models, got %d", len(models))
 	}
 
 	if models[0].Meta.UUID != "1234-5678-9101" {
 		t.Errorf("Expected model UUID %s, got %s", "1234-5678-9101", models[0].Meta.UUID)
 	}
-	if models[1].Meta.UUID != "1234-5678-9105" {
-		t.Errorf("Expected model UUID %s, got %s", "1234-5678-9105", models[1].Meta.UUID)
+	if models[2].Meta.UUID != "1234-5678-9105" {
+		t.Errorf("Expected model UUID %s, got %s", "1234-5678-9105", models[2].Meta.UUID)
 	}
 
 }


### PR DESCRIPTION
Models can now track who their parents are, if applicable. Furthermore, metadata now supports multiple updaters. One last noteworthy change: Metadata is now considered equal if and only if their UUIDs are the same. Relates to #37 and #40.